### PR TITLE
Adds trigger that combines day and room fields in a session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
 **/node_modules/*
 **/.firebaserc
-*/npm-debug.log
+**/*.log
 *~

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,3 +15,47 @@ exports.duplicateFeedback = functions.database.ref('/votes/{userId}/{sessionId}'
 
         return baseNode.child('sessions').child(sessionId).child('votes').child(userId).set(vote);
     });
+
+// Listens for any change on a session's "day" and created a field called day_room.
+// It's a combined field for easier filtering.
+exports.combineSessionDayAndRoomOnDay = functions.database.ref('/sessions/{sessionId}/day')
+    .onWrite(event => {
+        if (!event.data.exists()) {
+            return;
+        }
+
+        const day = event.data.val();
+
+        const roomRef = event.data.ref.parent.child('room');
+        return roomRef.once("value")
+            .then(snapshot => {
+                const room = snapshot.val();
+
+                console.log(`Day: ${day}, Room: ${room}`)
+
+                return event.data.ref.parent.child("day_room").set(`${day}_${room}`)
+            });
+
+        console.log(`Day: ${day}, Room: ${room}`)
+
+        return event.data.ref.parent.child("day_room").set(`${day}_${room}`)
+    });
+
+exports.combineSessionDayAndRoomOnRoom = functions.database.ref('/sessions/{sessionId}/room')
+    .onWrite(event => {
+        if (!event.data.exists()) {
+            return;
+        }
+
+        const room = event.data.val();
+
+        const dayRef = event.data.ref.parent.child('day');
+        return dayRef.once("value")
+            .then(snapshot => {
+                const day = snapshot.val();
+
+                console.log(`Day: ${day}, Room: ${room}`)
+
+                return event.data.ref.parent.child("day_room").set(`${day}_${room}`)
+            })
+    });

--- a/functions/index.js
+++ b/functions/index.js
@@ -25,20 +25,13 @@ exports.combineSessionDayAndRoomOnDay = functions.database.ref('/sessions/{sessi
         }
 
         const day = event.data.val();
-
         const roomRef = event.data.ref.parent.child('room');
+
         return roomRef.once("value")
             .then(snapshot => {
                 const room = snapshot.val();
-
-                console.log(`Day: ${day}, Room: ${room}`)
-
                 return event.data.ref.parent.child("day_room").set(`${day}_${room}`)
             });
-
-        console.log(`Day: ${day}, Room: ${room}`)
-
-        return event.data.ref.parent.child("day_room").set(`${day}_${room}`)
     });
 
 exports.combineSessionDayAndRoomOnRoom = functions.database.ref('/sessions/{sessionId}/room')
@@ -48,14 +41,11 @@ exports.combineSessionDayAndRoomOnRoom = functions.database.ref('/sessions/{sess
         }
 
         const room = event.data.val();
-
         const dayRef = event.data.ref.parent.child('day');
+
         return dayRef.once("value")
             .then(snapshot => {
                 const day = snapshot.val();
-
-                console.log(`Day: ${day}, Room: ${room}`)
-
                 return event.data.ref.parent.child("day_room").set(`${day}_${room}`)
             })
     });


### PR DESCRIPTION
When using Firebase, it is not possible to query by multiple fields. For this app this is very inconvenient, for example in case we want to show a list of sessions for a specific day and specific room. In order to achieve this, the easiest and best-performance solution is to add a field called day_room that combines those fields, this way the implementation in the client is very simple.

With this function, each time a Session's `day` or `room` is updated, so will do `day_room` just concatenating both values.
